### PR TITLE
Added Observer pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     * [ ] [Mediator](#mediator)
     * [ ] [Memento](#memento)
     * [ ] [Null Object](#null-object)
-    * [ ] [Observer](#observer)
+    * [x] [Observer](#observer)
     * [ ] [State](#state)
     * [ ] [Template](#template)
     * [ ] [Visitor](#visitor)
@@ -186,12 +186,38 @@ Null Object
 
 **In progress**
 
-Observer
+[Observer](/src/main/kotlin/oop/Observer)
 ------------
 
 > It defines a _one-to-many_ dependency between object so that when one changes its state, all its dependents are notified and updated automatically.
 
-**In progress**
+### Example
+
+```kotlin
+interface Observer<in T> {
+  fun onValueChange(newValue: T, oldValue: T)
+}
+
+class CustomersObserver : Observer<Int> {
+  override fun onValueChange(newValue: Int, oldValue: Int) = when {
+    newValue > oldValue -> println("A new customer entered. Current customers $newValue")
+    else -> println("A customer left. Current customers: $newValue")
+  }
+}
+
+class Shop(private val observer: Observer<Int>) {
+  var currentCustomers by Delegates.observable(0) { _, old, new ->
+    observer.onValueChange(new, old)
+  }
+}
+```
+
+### Usage
+
+```kotlin
+shop.currentCustomers++ // prints "A new customer entered ..."
+shop.currentCustomers-- // prints "A customer left ..."
+```
 
 State
 -------

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Null Object
 
 > It defines a _one-to-many_ dependency between object so that when one changes its state, all its dependents are notified and updated automatically.
 
+In Kotlin, this pattern is extremely easy to implement thanks to [property delegation](https://kotlinlang.org/docs/reference/delegated-properties.html)
+
 ### Example
 
 ```kotlin
@@ -429,7 +431,7 @@ kitchen.cook()
 
 > It attachs additional responsabilities to an object dynamically.
 
-In Kotlin, we don't need to redefine the methods of the decorated interface. We can use `by` to delegate those methods to the decorated class.
+In Kotlin, we don't need to redefine the methods of the decorated interface. We can use `by` to [delegate](https://kotlinlang.org/docs/reference/delegation.html) those methods to the decorated class.
 
 ### Example
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ group 'com.cloudcoders'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.1.0'
+    ext.kotlin_version = '1.1.1'
 
     repositories {
         mavenCentral()
@@ -24,4 +24,5 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile "com.natpryce:hamkrest:1.4.0.0"
 }

--- a/src/main/kotlin/oop/Observer/CustomersObserver.kt
+++ b/src/main/kotlin/oop/Observer/CustomersObserver.kt
@@ -1,0 +1,11 @@
+package oop.Observer
+
+
+class CustomersObserver : Observer<Int> {
+
+  override fun onValueChange(newValue: Int, oldValue: Int) = when {
+    newValue > oldValue -> println("A new customer entered. Current customers: $newValue")
+    else -> println("A customer left. Current customers: $newValue")
+  }
+
+}

--- a/src/main/kotlin/oop/Observer/Observer.kt
+++ b/src/main/kotlin/oop/Observer/Observer.kt
@@ -1,0 +1,6 @@
+package oop.Observer
+
+
+interface Observer<in T> {
+  fun onValueChange(newValue: T, oldValue: T)
+}

--- a/src/main/kotlin/oop/Observer/Shop.kt
+++ b/src/main/kotlin/oop/Observer/Shop.kt
@@ -1,0 +1,15 @@
+package oop.Observer
+
+import kotlin.properties.Delegates
+
+class Shop(private val customersObserver : CustomersObserver) {
+
+  private var currentCustomers by Delegates.observable(0) { _, old, new ->
+    customersObserver.onValueChange(new, old)
+  }
+
+  fun customerEnter() = currentCustomers++
+
+  fun customerLeave() = currentCustomers--
+
+}

--- a/src/test/kotlin/oop/Observer/ObserverTest.kt
+++ b/src/test/kotlin/oop/Observer/ObserverTest.kt
@@ -1,0 +1,35 @@
+package oop.Observer
+
+import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.assertion.assert
+import org.junit.Test
+import kotlin.properties.Delegates
+
+
+class ObserverTest {
+
+  var observer = object : Observer<Int> {
+    override fun onValueChange(newValue: Int, oldValue: Int) {
+      timesChanged++
+    }
+  }
+
+  var counter by Delegates.observable(0) { _, old, new ->
+    observer.onValueChange(new, old)
+  }
+
+  var timesChanged = 0
+
+  val `is` = { number: Int -> Matcher(Int::equals, number) }
+
+  @Test
+  internal fun `observer should increment timesChanged on change`() {
+    assert.that(timesChanged, `is`(0))
+
+    counter++
+    assert.that(timesChanged, `is`(1))
+
+    counter--
+    assert.that(timesChanged, `is`(2))
+  }
+}


### PR DESCRIPTION
Solves #13  

It is ready to be merged, BUT I think the example can be improved.

By using an anonymous implementation for the _Observer_ :

```kotlin
interface Observer<in T> {
  fun onValueChange(newValue: T, oldValue: T)
}

class Shop {
  private val observer = object : Observer<Int> {
    override fun onValueChange(newValue: Int, oldValue: Int) = when {
      newValue > oldValue -> println(...)
      else -> println(...)
    }
  }

  private var currentCustomers by Delegates.observable(0) { _, old, new ->
    observer.onValueChange(new, old)
  }

  // ...
}
```

Or even removing the _Observer_ interface :

```kotlin
class Shop {
  private var currentCustomers by Delegates.observable(0) { _, old, new ->
    onValueChange(new, old)
  }

  private fun onValueChange(newValue: Int, oldValue: Int) = // ...

  // ...
}
```
Although this last one may not respect the SOLID rules 🤔 

What do you think? Should we change it before merging?