### PR TITLE
Added Memento pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Kotlin OOP and FP Design Patterns
     * [ ] [Interpreter](#interpreter)
     * [ ] [Iterator](#iterator)
     * [ ] [Mediator](#mediator)
-    * [ ] [Memento](#memento)
+    * [x] [Memento](#memento)
     * [ ] [Null Object](#null-object)
     * [x] [Observer](#observer)
     * [x] [State](#state)
@@ -174,12 +174,40 @@ Mediator
 
 **In progress**
 
-Memento
+[Memento](/src/main/kotlin/oop/Memento)
 ---------
 
 > It captures and externalizes an object's internal state so it can get back to this state later without violating encapsulation
 
-**In progress**
+### Example
+
+```kotlin
+data class Memento<out T>(val state: T)
+
+class Originator<T>(var state: T) {
+  fun saveToMemento() = Memento(state)
+  fun loadFromMemento(memento: Memento<T>) {
+    state = memento.state
+  }
+}
+
+class CareTaker<T> {
+  val mementoList = mutableListOf<Memento<T>>()
+}
+```
+
+### Usage
+
+```kotlin
+val changingClass = Originator("Hello world")
+val states = CareTaker<String>()
+
+changingClass.state += "!"
+states.mementoList.add(changingClass.saveToMemento())
+
+changingClass.state = "I've made a mistake :("
+changingClass.loadFromMemento(states.mementoList[0])
+```
 
 Null Object
 -----------

--- a/src/main/kotlin/oop/Memento/CareTaker.kt
+++ b/src/main/kotlin/oop/Memento/CareTaker.kt
@@ -1,0 +1,5 @@
+package oop.Memento
+
+class CareTaker<T> {
+  val mementoList = mutableListOf<Memento<T>>()
+}

--- a/src/main/kotlin/oop/Memento/Memento.kt
+++ b/src/main/kotlin/oop/Memento/Memento.kt
@@ -1,0 +1,3 @@
+package oop.Memento
+
+data class Memento<out T>(val state: T)

--- a/src/main/kotlin/oop/Memento/Originator.kt
+++ b/src/main/kotlin/oop/Memento/Originator.kt
@@ -1,0 +1,8 @@
+package oop.Memento
+
+class Originator<T>(var state : T) {
+  fun saveToMemento() = Memento(state)
+  fun loadFromMemento(memento: Memento<T>) {
+    state = memento.state
+  }
+}

--- a/src/test/kotlin/oop/Memento/MementoTest.kt
+++ b/src/test/kotlin/oop/Memento/MementoTest.kt
@@ -1,0 +1,43 @@
+package oop.Memento
+
+import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.assertion.assert
+import org.junit.Test
+
+class MementoTest {
+
+  fun <T> `is`(list: List<T>): Matcher<List<T>> = Matcher(List<T>::equals, list)
+  fun <T> `is`(list: Memento<T>): Matcher<Memento<T>> = Matcher(Memento<T>::equals, list)
+
+  @Test
+  fun `memento state should be equal to last originator state`() {
+    val originator = Originator(emptyList<Int>())
+    originator.state = listOf(1,2,3)
+
+    val memento = originator.saveToMemento()
+
+    assert.that(memento.state, `is`(memento.state))
+  }
+
+  @Test
+  fun `originator state should be equal to last memento loaded`() {
+    val memento = Memento(listOf(1,2,3))
+    val originator = Originator(emptyList<Int>())
+
+    originator.loadFromMemento(memento)
+
+    assert.that(originator.state, `is`(memento.state))
+  }
+
+  @Test
+  fun `care taker should store mementos`() {
+    val careTaker = CareTaker<List<Int>>()
+    val originator = Originator(listOf(1,2,3))
+    val memento = originator.saveToMemento()
+
+    careTaker.mementoList.add(memento)
+
+    assert.that(careTaker.mementoList[0], `is`(memento))
+  }
+
+}


### PR DESCRIPTION
Close #20 

I think this pattern has no sense in Kotlin. We could join `Originator` and `Memento` and we could make `CareTaker` dissappear because it is only a wrapper of a List of Mementos. Memento has a immutable state and if you want to modify it's state you would create a new Memento with another state and store them in a List in case you want to get back to some of them.

What do you think?